### PR TITLE
Removed libgcc-ng and libstdcxx-ng pins as they are no longer needed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,18 @@ build:
   number: 2
 
 requirements:
+  host:
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                     # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}               # [x86_64 and c_compiler_version == "7.2.*"]
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake {{ cmake }}
     - ninja {{ ninja }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                     # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}               # [x86_64 and c_compiler_version == "7.2.*"]
   run_constrained:
     # Cannot be installed at the same time as boost-cpp as it clobbers the mp11 headers
     - boost-cpp <0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,21 +11,14 @@ source:
   sha256: f0df3ae138687154382361019fa43298821b50c80e7bd60dd7bb30de7819e204
 
 build:
-  number: 1
+  number: 2
 
 requirements:
-  host:
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake {{ cmake }}
     - ninja {{ ninja }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   run_constrained:
     # Cannot be installed at the same time as boost-cpp as it clobbers the mp11 headers
     - boost-cpp <0a0


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed pins for libgcc-ng and libstdcxx-ng as they are no longer needed.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
